### PR TITLE
Dev

### DIFF
--- a/cve_parser/defaults/main.yml
+++ b/cve_parser/defaults/main.yml
@@ -1,11 +1,14 @@
 ---
 enable_mattermost: no
 enable_confluence: yes
+enable_git_backup: yes
 
+#Mattermost Settings
 mattermost_channel: "cve-report"
 mattermost_url: "https://mymattermost.com"
 mattermost_token: "abc123456789"
 
+#Confluence Settings
 confluence_parent_title: "Network CVE Report"
 confluence_parent_query: "json.page.results[?title=='{{ confluence_parent_title }}'].id"
 confluence_space: "NETWORK"
@@ -13,5 +16,13 @@ confluence_url: myconfluence.atlassian.net
 confluence_user: jdoe@gmail.com
 confluence_token: "abc123456789"
 
+#Cisco PSIRT Settings
 cisco_psirt_clientid: "123456789"
 cisco_psirt_clientsecret: "abc123456789"
+
+#GIT backup settings
+cve_data_dir: /var/tmp/cve/
+cve_data_file: "{{ cve_data_dir }}cve_data.json"
+cve_data_repository: "git@192.168.6.101:amack/network-cve-data.git"
+git_name: ansible tower
+git_email: ansible_tower@gmail.com

--- a/cve_parser/tasks/cisco_psirt.yml
+++ b/cve_parser/tasks/cisco_psirt.yml
@@ -3,7 +3,7 @@
     url: https://cloudsso.cisco.com/as/token.oauth2
     method: POST
     body_format: form-urlencoded
-    body: "client_id=r6fj4chscmx2t7sh43ay65mb&client_secret=9mKj7xSTGttNMjFq8pNz8Jhf&grant_type=client_credentials"
+    body: "client_id={{ cisco_psirt_clientid }}&client_secret={{ cisco_psirt_clientsecret }}&grant_type=client_credentials"
     headers:
       Accept: application/json
       Content-Type: application/x-www-form-urlencoded
@@ -26,6 +26,7 @@
   loop_control:
     label: "{{ item.key }}"
   when: device_data.nxos is defined
+  delegate_to: localhost
 
 - name: Get Cisco PSIRT CVE List IOS
   uri:
@@ -57,47 +58,4 @@
   loop_control:
     label: "{{ item.key }}"
   when: device_data.iosxe is defined
-  delegate_to: localhost
-
-#cve_mapping filter is found in filter_plugs>cve_mapping.py
-- name: Set NXOS CVE mapping as fact
-  set_fact:
-    nxos_cves: "{{ nxos_cve_list | cve_mapping('nxos') }}"
-  run_once: true
-  when: device_data.nxos is defined
-  delegate_to: localhost
-
-- name: Set IOS CVE mapping as fact
-  set_fact:
-    ios_cves: "{{ ios_cve_list | cve_mapping('ios') }}"
-  run_once: true
-  when: device_data.ios is defined
-  delegate_to: localhost
-
-- name: Set IOS-XE CVE mapping as fact
-  set_fact:
-    iosxe_cves: "{{ iosxe_cve_list | cve_mapping('iosxe') }}"
-  run_once: true
-  when: device_data.iosxe is defined
-  delegate_to: localhost
-
-- name: Merge IOS CVEs into main dictionary
-  set_fact:
-    cve_data: "{{ device_data|combine(ios_cves, recursive=true) }}"
-  run_once: true
-  when: ios_cves is defined
-  delegate_to: localhost
-
-- name: Merge IOS-XE CVEs into main dictionary
-  set_fact:
-    cve_data: "{{ cve_data|combine(iosxe_cves) }}"
-  run_once: true
-  when: iosxe_cves is defined
-  delegate_to: localhost
-
-- name: Merge NXOS CVEs into main dictionary
-  set_fact:
-    cve_data: "{{ cve_data|combine(nxos_cves,recursive=true) }}"
-  run_once: true
-  when: nxos_cves is defined
   delegate_to: localhost

--- a/cve_parser/tasks/confluence.yml
+++ b/cve_parser/tasks/confluence.yml
@@ -21,6 +21,7 @@
     status_code: 201,200
     body_format: json
   register: confluence_pages
+  delegate_to: localhost
   run_once: true
 
 - name: Set Confluence Data as Facts
@@ -28,6 +29,7 @@
     confluence_page_titles: "{{ confluence_pages.json.page.results | map(attribute='title')|list }}" #Map all page titles to list for searching
     confluence_parent_page_id: "{{ confluence_pages | json_query(confluence_parent_query) }}" #Query is found in defaults/main.yml
   run_once: true
+  delegate_to: localhost
 
 - name: Get Confluence Page Version
   uri:
@@ -40,30 +42,21 @@
     body_format: json
   register: confluence_version_json
   run_once: true
+  delegate_to: localhost
   when: confluence_parent_page_id | length
 
-- name: Set Confluence Version as Fact
-  set_fact:
-    confluence_page_version: "{{ confluence_version_json.json.version.number | int + 1 }}" #API requires you to increment by 1 the version
+- name: Create Network CVE Parent Page
+  uri:
+    url: https://{{ confluence_url }}/wiki/rest/api/content/
+    method: POST
+    user: "{{ confluence_user }}"
+    password: "{{ confluence_token }}"
+    force_basic_auth: yes
+    status_code: 201,200
+    body: "{{ lookup('template','templates/confluence_parent.j2') }}"
+    body_format: json
   run_once: true
-  when: confluence_parent_page_id | length
-
-- name: Create Parent Page
-  block:
-    - debug:
-        msg: "{{ lookup('template','templates/confluence_parent.j2') }}"
-
-    - name: Create Network CVE Parent Page
-      uri:
-        url: https://{{ confluence_url }}/wiki/rest/api/content/
-        method: POST
-        user: "{{ confluence_user }}"
-        password: "{{ confluence_token }}"
-        force_basic_auth: yes
-        status_code: 201,200
-        body: "{{ lookup('template','templates/confluence_parent.j2') }}"
-        body_format: json
-      run_once: true
+  delegate_to: localhost
   when:
     - confluence_parent_title is defined
     - confluence_parent_title not in confluence_page_titles
@@ -80,5 +73,6 @@
     body_format: json
   register: create_child_page
   run_once: true
+  delegate_to: localhost
   when:
     - confluence_parent_title is defined

--- a/cve_parser/tasks/confluence.yml
+++ b/cve_parser/tasks/confluence.yml
@@ -57,20 +57,6 @@
     body_format: json
   run_once: true
   delegate_to: localhost
-  when: confluence_parent_page_id | length
-
-- name: Create Network CVE Parent Page
-  uri:
-    url: https://{{ confluence_url }}/wiki/rest/api/content/
-    method: POST
-    user: "{{ confluence_user }}"
-    password: "{{ confluence_token }}"
-    force_basic_auth: yes
-    status_code: 201,200
-    body: "{{ lookup('template','templates/confluence_parent.j2') }}"
-    body_format: json
-  run_once: true
-  delegate_to: localhost
   when:
     - confluence_parent_title is defined
     - confluence_parent_title not in confluence_page_titles

--- a/cve_parser/tasks/cve_data.yml
+++ b/cve_parser/tasks/cve_data.yml
@@ -1,0 +1,56 @@
+#cve_mapping filter is found in filter_plugs>cve_mapping.py
+- name: Set NXOS CVE mapping as fact
+  set_fact:
+    nxos_cves: "{{ nxos_cve_list | cve_mapping('nxos') }}"
+  run_once: true
+  when: device_data.nxos is defined
+  delegate_to: localhost
+
+- name: Set IOS CVE mapping as fact
+  set_fact:
+    ios_cves: "{{ ios_cve_list | cve_mapping('ios') }}"
+  run_once: true
+  when: device_data.ios is defined
+  delegate_to: localhost
+
+- name: Set IOS-XE CVE mapping as fact
+  set_fact:
+    iosxe_cves: "{{ iosxe_cve_list | cve_mapping('iosxe') }}"
+  run_once: true
+  when: device_data.iosxe is defined
+  delegate_to: localhost
+
+- name: Create main CVE data dictionary
+  set_fact:
+    cve_data: {}
+  run_once: true
+  when: ios_cves is defined
+  delegate_to: localhost
+
+- name: Merge Network Device Data with main dictionary
+  set_fact:
+    cve_data: "{{ cve_data|combine(device_data, recursive=true) }}"
+  run_once: true
+  when: ios_cves is defined
+  delegate_to: localhost
+
+- name: Merge IOS CVEs into main dictionary
+  set_fact:
+    cve_data: "{{ cve_data|combine(ios_cves, recursive=true) }}"
+  run_once: true
+  when: ios_cves is defined
+  delegate_to: localhost
+
+- name: Merge IOS-XE CVEs into main dictionary
+  set_fact:
+    cve_data: "{{ cve_data|combine(iosxe_cves, recursive=true) }}"
+  run_once: true
+  when: iosxe_cves is defined
+  delegate_to: localhost
+
+- name: Merge NXOS CVEs into main dictionary
+  set_fact:
+    cve_data: "{{ cve_data|combine(nxos_cves, recursive=true) }}"
+  run_once: true
+  when: nxos_cves is defined
+  delegate_to: localhost

--- a/cve_parser/tasks/data_backup.yml
+++ b/cve_parser/tasks/data_backup.yml
@@ -1,0 +1,66 @@
+---
+- name: Clone the backup repo
+  git:
+    repo: "{{ cve_data_repository }}"
+    dest: "{{ cve_data_dir }}"
+    accept_hostkey: yes
+    force: yes
+    key_file: "~/.ssh/id_rsa"
+  register: clone_result
+  delegate_to: localhost
+  run_once: true
+  when:
+    - cve_data_repository is defined
+    - cve_data_dir is defined
+
+- name: Create CVE data file
+  copy:
+    dest: "{{ cve_data_file }}"
+    content: "{{ cve_data | to_nice_json }}"
+  delegate_to: localhost
+  run_once: true
+  when:
+    - cve_data_file is defined
+
+- name: Add CVE data to the repository
+  block:
+    - name: Add CVE data to repo
+      command: "git add *.json"
+      args:
+        chdir: "{{ cve_data_dir }}"
+      delegate_to: localhost
+      changed_when: False
+      run_once: true
+
+    - name: Get the status of the repository
+      command: "git status"
+      args:
+        chdir: "{{ cve_data_dir }}"
+      register: status_results
+      changed_when: False
+      ignore_errors: yes
+      delegate_to: localhost
+      run_once: true
+
+    - name: Get Current Date
+      set_fact:
+        current_date: "{{ lookup('pipe','date +%m-%d-%H-%M') }}"
+      delegate_to: localhost
+      run_once: true
+
+    - name: Commit the changes
+      command: "git commit -am 'CVE Data Backup - {{ current_date }}'"
+      args:
+        chdir: "{{ cve_data_dir }}"
+      delegate_to: localhost
+      run_once: true
+      when: status_results.stdout is search('Changes')
+
+    - name: Push the changes
+      command: "git push origin master"
+      args:
+        chdir: "{{ cve_data_dir }}"
+      run_once: true
+      when: status_results.stdout is search('Changes')
+      delegate_to: localhost
+  when: cve_data_repository is defined

--- a/cve_parser/tasks/data_load.yml
+++ b/cve_parser/tasks/data_load.yml
@@ -1,0 +1,57 @@
+- name: Load existing CVE Data
+  block:
+    - name: Clone the backup repo
+      git:
+        repo: "{{ cve_data_repository }}"
+        dest: "{{ cve_data_dir }}"
+        accept_hostkey: yes
+        force: yes
+        key_file: "~/.ssh/id_rsa"
+      register: clone_result
+
+    - name: Check that CVE file exists
+      stat:
+        path: "{{ cve_data_file }}"
+      register: stat_result
+
+    - name: Include existing CVE data as var
+      include_vars:
+        file: "{{ cve_data_file }}"
+        name: existing_cve_data
+      when: stat_result.stat.exists
+
+    - name: Map existing IOS CVE IDs to list
+      set_fact:
+        existing_ios_cves: "{{ existing_cve_data.ios | json_query('*.*[*].cves')|list|flatten|unique }}"
+      when: existing_cve_data.ios is defined
+
+    - name: Map existing IOS-XE CVE IDs to list
+      set_fact:
+        existing_iosxe_cves: "{{ existing_cve_data.iosxe | json_query('*.*[*].cves')|list|flatten|unique }}"
+      when: existing_cve_data.iosxe is defined
+
+    - name: Map existing NXOS CVE IDs to list
+      set_fact:
+        existing_nxos_cves: "{{ existing_cve_data.nxos | json_query('*.*[*].cves')|list|flatten|unique }}"
+      when: existing_cve_data.nxos is defined
+
+    - name: Merge Existing IOS CVEs Into Existing CVE Dictionary
+      set_fact:
+        existing_cves: "{{ existing_cves | default({}) | combine({ 'ios': existing_ios_cves }) }}"
+      when: existing_ios_cves is defined
+
+    - name: Merge Existing IOSXE CVEs Into Existing CVE Dictionary
+      set_fact:
+        existing_cves: "{{ existing_cves | default({}) | combine ({ 'iosxe': existing_iosxe_cves }) }}"
+      when: existing_iosxe_cves is defined
+
+    - name: Merge Existing NXOS CVEs Into Existing CVE Dictionary
+      set_fact:
+        existing_cves: "{{ existing_cves | default({}) | combine ({ 'nxos': existing_nxos_cves }) }}"
+      when: existing_nxos_cves is defined
+
+  when:
+    - cve_data_repository is defined
+    - cve_data_dir is defined
+  delegate_to: localhost
+  run_once: true

--- a/cve_parser/tasks/main.yml
+++ b/cve_parser/tasks/main.yml
@@ -1,6 +1,13 @@
 ---
+- name: Load Existing CVE Data
+  include_tasks: data_load.yml
+  when:
+    - cve_data_repository is defined
+    - cve_data_dir is defined
+
 - name: Include OS Specific Tasks
   include_tasks: "{{ ansible_network_os }}.yml"
+  when: ansible_network_os == 'nxos' or ansible_network_os == 'ios'
 
 - name: Get Device Data Set
   set_fact:
@@ -12,6 +19,13 @@
   include_tasks: cisco_psirt.yml
   when: ansible_network_os == 'nxos' or ansible_network_os == 'ios'
 
+- name: Compile CVE Data
+  include_tasks: cve_data.yml
+
 - name: Include Confluence Tasks
   include_tasks: confluence.yml
   when: enable_confluence
+
+- name: Include GIT Backup Tasks
+  include_tasks: data_backup.yml
+  when: enable_git_backup

--- a/cve_parser/templates/confluence_child.j2
+++ b/cve_parser/templates/confluence_child.j2
@@ -9,12 +9,12 @@
       "value": """
       <p style="font-size:26px"><u>Device OS:</u></p>
       <p><ac:structured-macro ac:name="toc\"/></p>
-      {% for platform, os in cve_data.items() %}
+      {% for platform, info in cve_data.items() %}
       <h1><u>{{ platform | upper }}</u></h1>
-      {% for version, cves in os.items() %}
+      {% for version, data in info.items() %}
       <h2>Version: {{ version }}</h2>
       <h3>Devices Affected</h3>
-      {% for device in cves['hosts'] %}
+      {% for device in data['hosts'] %}
       <ul>
         <li>{{ device }}</li>
       </ul>
@@ -30,14 +30,33 @@
         </tr>
       </thead>
       <tbody>
-      {% for cve in cves.data|sort(attribute='severity') %}
+      {% set unmapped_cves = [] %}
+      {% for cve in data.data|sort(attribute='severity') %}
+        {% if existing_cves is defined %}
+          {% for item in cve.cves %}
+            {% if item not in existing_cves[platform] %}
+               {{ unmapped_cves.append(item) }}
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+        {% if unmapped_cves|length %}
+        <tr>
+          <td style="text-align:center"><a href="{{ cve.url }}">{{ unmapped_cves|join(', ') }}</a></td>
+          <td style="text-align:center">{{ cve.severity }}</td>
+          <td style="text-align:center">{{ cve.title }}</td>
+          <td style="text-align:center">{% if cve.fixed_version is string %}{{ cve.fixed_version|default() }}{% else %}{{ cve.fixed_version|join(',  ')|default() }}{% endif %}</td>
+          <td style="text-align:center"></td>
+        </tr>
+        {% elif existing_cves is not defined %}
         <tr>
           <td style="text-align:center"><a href="{{ cve.url }}">{{ cve.cves|join(', ') }}</a></td>
           <td style="text-align:center">{{ cve.severity }}</td>
           <td style="text-align:center">{{ cve.title }}</td>
-          <td style="text-align:center">{% if cve.fixed_version is string %}{{ cve.fixed_version|default() }}{% else %}{{ cve.fixed_version|join(',')|default() }}{% endif %}</td>
+          <td style="text-align:center">{% if cve.fixed_version is string %}{{ cve.fixed_version|default() }}{% else %}{{ cve.fixed_version|join(',  ')|default() }}{% endif %}</td>
           <td style="text-align:center"></td>
         </tr>
+        {% else %}
+        {% endif %}
       {% endfor %}
 </tbody>
 </table>{% endfor %}{% endfor %}"""


### PR DESCRIPTION
- Added GIT backup option for storing the documented CVEs in JSON format
- Added tasks to clone repo and load CVE JSON into a var for comparison to avoid duplicate tracking
- Split CVE mapping tasks to cve_data.yml from cisco_psirt.yml
- Added conditional in Confluence_child.j2 to detect if existing_cves var is present